### PR TITLE
Fix piece collision locking

### DIFF
--- a/client/src/components/CoopGameBoard.tsx
+++ b/client/src/components/CoopGameBoard.tsx
@@ -184,8 +184,12 @@ const CoopGameBoard: React.FC<CoopGameBoardProps> = ({
       return false;
     }
 
-    // Check collision with the other active piece (do not lock)
+    // Check collision with the other active piece
     if (wouldCollidePiece(piece, otherPiece, dx, dy)) {
+      // If moving downwards, treat it as a landing
+      if (dy > 0) {
+        placePiece(player);
+      }
       return false;
     }
     


### PR DESCRIPTION
## Summary
- lock a piece when it collides downward with the other active piece

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68455c7123f4832382675337199ea347