### PR TITLE
Fix coop piece lock when blocked

### DIFF
--- a/client/src/components/CoopGameBoard.tsx
+++ b/client/src/components/CoopGameBoard.tsx
@@ -186,10 +186,7 @@ const CoopGameBoard: React.FC<CoopGameBoardProps> = ({
 
     // Check collision with the other active piece
     if (wouldCollidePiece(piece, otherPiece, dx, dy)) {
-      // If moving downwards, treat it as a landing
-      if (dy > 0) {
-        placePiece(player);
-      }
+      // Return without locking so the piece stays active when blocked
       return false;
     }
     


### PR DESCRIPTION
## Summary
- stop locking a player's piece when it collides with the other active piece so it stays active

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68455fb65da883238583346765a86d5d