### PR TITLE
Fix co-op spawning collisions and timer resets

### DIFF
--- a/client/src/components/GameBoard.tsx
+++ b/client/src/components/GameBoard.tsx
@@ -125,6 +125,12 @@ const GameBoard: React.FC<GameBoardProps> = ({
   // Game loop - automatically move piece down (but not during hard drop)
   const lastTimeRef = useRef<number>(0);
   const frameIdRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (!isPlaying || isGameOver) {
+      lastTimeRef.current = 0;
+    }
+  }, [isPlaying, isGameOver]);
   
   useEffect(() => {
     if (!isPlaying || isGameOver || isHardDropping) return;


### PR DESCRIPTION
### Motivation
- Prevent pieces from spawning into occupied cells or colliding with the other player's active piece in co-op mode which caused premature game overs or stuck pieces. 
- Ensure timers and frame timing are reset when a game stops/restarts to avoid immediate drop spikes or lingering hard-drop timers. 
- Centralize game-over handling on spawn/placement to make behavior consistent across co-op flows.

### Description
- Added spawn helpers: `createPiece`, `getSpawnPosition`, `canSpawnPiece`, and `handleSpawnGameOver` and changed `spawnNewPieces` to accept a board snapshot and validate new spawns against the snapshot and the other active piece in `client/src/components/CoopGameBoard.tsx`.
- Modified `wouldCollideBoard` to accept an optional `boardSnapshot` parameter so spawn/validation can check a specific board state rather than the live `board` state. 
- Updated `placePiece` flow to use the centralized `handleSpawnGameOver` and to validate the next spawned piece against the updated board before setting it. 
- Reset frame timers when play stops by clearing `lastTimeRef.current` in both `client/src/components/GameBoard.tsx` and `client/src/components/CoopGameBoard.tsx` to avoid immediate fall updates after restart. 
- Improved restart handling to build a fresh `newBoard` and pass it to `spawnNewPieces` so initial spawn validation runs against the actual cleared board.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a41f40fc83238044aa801c600a20)