### PR TITLE
Fix hard-drop lock to use latest board/piece state so moved pieces don't snap back

### DIFF
--- a/client/src/components/CoopGameBoard.tsx
+++ b/client/src/components/CoopGameBoard.tsx
@@ -66,6 +66,10 @@ const CoopGameBoard: React.FC<CoopGameBoardProps> = ({
     player1: NodeJS.Timeout | null;
     player2: NodeJS.Timeout | null;
   }>({ player1: null, player2: null });
+
+  const boardRef = useRef(board);
+  const player1PieceRef = useRef(player1Piece);
+  const player2PieceRef = useRef(player2Piece);
   
   // Reset board when isPlaying changes
   useEffect(() => {
@@ -84,6 +88,18 @@ const CoopGameBoard: React.FC<CoopGameBoardProps> = ({
       setScore(0);
     }
   }, [isPlaying, boardWidth, boardHeight, setScore]);
+
+  useEffect(() => {
+    boardRef.current = board;
+  }, [board]);
+
+  useEffect(() => {
+    player1PieceRef.current = player1Piece;
+  }, [player1Piece]);
+
+  useEffect(() => {
+    player2PieceRef.current = player2Piece;
+  }, [player2Piece]);
   
   // Check for victory condition
   useEffect(() => {
@@ -500,7 +516,7 @@ const CoopGameBoard: React.FC<CoopGameBoardProps> = ({
   const placePiece = (player: 1 | 2) => {
     if (gameOver) return;
     
-    const piece = player === 1 ? player1Piece : player2Piece;
+    const piece = player === 1 ? player1PieceRef.current : player2PieceRef.current;
     if (!piece) return;
     
     // Clear hard drop timer if it exists
@@ -521,7 +537,7 @@ const CoopGameBoard: React.FC<CoopGameBoardProps> = ({
     }
     
     // Create new board with piece locked in place
-    const newBoard = board.map(row => [...row]);
+    const newBoard = boardRef.current.map(row => [...row]);
     
     // Place piece on board
     piece.shape.forEach((row, rowIndex) => {


### PR DESCRIPTION
### Motivation
- Players could move a piece during the post-hard-drop lock delay but the delayed lock used stale state so the piece snapped back to its original landing position.
- The goal is to ensure the delayed `lock`/`place` logic uses the most recent active piece and board state so moves during the lock window persist.

### Description
- Added `boardRef` and `activePieceRef` to `client/src/hooks/useTetris.ts` and update them via `useEffect` so the delayed `lockPiece` can read the latest state. 
- Modified `lockPiece` to accept an optional `pieceOverride` and to use `activePieceRef`/`boardRef` when resolving which piece and board to lock. 
- Added `boardRef`, `player1PieceRef`, and `player2PieceRef` to `client/src/components/CoopGameBoard.tsx` and updated `placePiece` to read the piece and board from those refs so co-op delayed placement uses the final moved position.
- Changes affect `useTetris` and `CoopGameBoard` so hard-drop delays now lock the piece at its updated position instead of the original drop spot.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a98fd0e4832386ca13035db82087)